### PR TITLE
docs: Add rule to never push directly to main branch

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -359,8 +359,11 @@ server.setRequestHandler(ListToolsRequestSchema, async () => ({
 - [ ] Documentation updated
 
 ## Git Commit and PR Rules (CRITICAL)
+- NEVER push directly to main branch - always create a feature branch and PR
 - NEVER add "Co-Authored-By: Claude" or any co-author attribution in commits
 - NEVER mention "Generated with Claude Code" or similar in commit messages
 - NEVER add Claude attribution, robot emojis (🤖), or AI-generated mentions in PR descriptions
 - NEVER reference Claude, AI assistance, or automated generation in any git-related text
 - Write commit messages and PR descriptions as if written directly by the developer
+- Always use feature branches: `git checkout -b feat/feature-name` or `fix/bug-name`
+- Always create PRs for review before merging to main


### PR DESCRIPTION
## Summary
Updates CLAUDE.md to add explicit rule about never pushing directly to main branch.

## Changes
- Added rule: "NEVER push directly to main branch - always create a feature branch and PR"
- Added branch naming convention examples: `feat/feature-name` or `fix/bug-name`
- Clarified that all changes should go through PR review process

## Context
This ensures better code review practices and prevents accidental direct pushes to main (like I just did with the image storage feature 😅).

## Testing
N/A - Documentation change only