### PR TITLE
Fix edit provider auto-selection

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -104,6 +104,23 @@ export class Config {
   }
 
   /**
+   * Get list of configured providers that support editing
+   */
+  static getConfiguredEditProviders(): ProviderName[] {
+    const configured: ProviderName[] = [];
+    const allNames: ProviderName[] = ['MOCK', 'OPENAI', 'STABILITY', 'REPLICATE', 'GEMINI', 'IDEOGRAM', 'BFL', 'LEONARDO', 'FAL', 'CLIPDROP'];
+
+    for (const name of allNames) {
+      const provider = this.createProvider(name);
+      if (provider?.isConfigured() && provider.getCapabilities().supportsEdit) {
+        configured.push(name);
+      }
+    }
+
+    return configured;
+  }
+
+  /**
    * Get default provider based on env or fallback chain
    */
   static getDefaultProvider(): ImageProvider {


### PR DESCRIPTION
## Summary
Fixed auto-selection for `image.edit` to only consider providers that support editing, preventing errors when a non-edit-capable provider is selected.

## Problem
When using `provider: "auto"` for `image.edit`, the system could select providers that don't support editing (like LEONARDO), resulting in error:
```
Provider LEONARDO does not support image editing. Try OpenAI or Stability providers instead.
```

## Solution
- Added `getConfiguredEditProviders()` method that filters providers by `supportsEdit` capability
- Updated `image.edit` handler to use only edit-capable providers for auto-selection
- Edit-capable providers: OPENAI, STABILITY, BFL, GEMINI, CLIPDROP, MOCK

## Changes
**src/config.ts:**
- Added `getConfiguredEditProviders()` method

**src/index.ts:**
- Modified `image.edit` case to check for auto-selection and use only edit-capable providers
- Improved error messages when no edit providers available

## Testing
- Build passes
- Auto-selection now correctly avoids non-edit providers
- Better user experience with clear error messages