### PR TITLE
Feat: Preserve aspect ratio in img-to-img transformations

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -305,6 +305,27 @@ const imageData = await this.getImageBuffer(input.baseImage);
 // Returns: { buffer: Buffer, mimeType: string }
 ```
 
+### Dimension Detection and Preservation
+```typescript
+// Detect image dimensions from any input format
+const dimensions = await this.detectImageDimensions(input.baseImage);
+// Returns: { width: number, height: number }
+
+// In edit operations, automatically preserve aspect ratio:
+let width = input.width;
+let height = input.height;
+if (!width || !height) {
+  const dimensions = await this.detectImageDimensions(input.baseImage);
+  width = width || dimensions.width;
+  height = height || dimensions.height;
+}
+
+// EditInput schema now supports optional width/height parameters
+// Defaults to input image dimensions if not specified
+// BFL and STABILITY providers use dimensions for aspect ratio control
+// GEMINI currently only supports 1:1 (square) aspect ratio
+```
+
 ### Image Download Pattern
 ```typescript
 // Download from URL and convert to data URL

--- a/src/providers/base.ts
+++ b/src/providers/base.ts
@@ -166,6 +166,44 @@ export abstract class ImageProvider {
   }
 
   /**
+   * Helper to detect image dimensions from buffer, data URL, or file path
+   * Uses sharp for accurate dimension detection
+   */
+  protected async detectImageDimensions(input: string): Promise<{ width: number; height: number }> {
+    try {
+      const sharp = (await import('sharp')).default;
+
+      // Get the buffer first
+      const { buffer } = await this.getImageBuffer(input);
+
+      // Use sharp to get metadata
+      const metadata = await sharp(buffer).metadata();
+
+      if (!metadata.width || !metadata.height) {
+        throw new ProviderError(
+          'Could not detect image dimensions',
+          this.name,
+          false
+        );
+      }
+
+      return {
+        width: metadata.width,
+        height: metadata.height
+      };
+    } catch (error) {
+      if (error instanceof ProviderError) {
+        throw error;
+      }
+      throw new ProviderError(
+        `Failed to detect image dimensions: ${error instanceof Error ? error.message : 'Unknown error'}`,
+        this.name,
+        false
+      );
+    }
+  }
+
+  /**
    * Helper to create timeout with AbortController and cleanup
    */
   protected createTimeout(ms: number = DEFAULT_TIMEOUT): AbortController {

--- a/src/providers/bfl.ts
+++ b/src/providers/bfl.ts
@@ -180,6 +180,15 @@ export class BFLProvider extends ImageProvider {
         // Extract base image data with size validation (supports both data URLs and file paths)
         const baseImageData = await this.getImageBuffer(input.baseImage);
 
+        // Detect dimensions if not provided
+        let width = input.width;
+        let height = input.height;
+        if (!width || !height) {
+          const dimensions = await this.detectImageDimensions(input.baseImage);
+          width = width || dimensions.width;
+          height = height || dimensions.height;
+        }
+
         let endpoint: string;
         let requestBody: Record<string, any>;
 
@@ -189,6 +198,8 @@ export class BFLProvider extends ImageProvider {
           requestBody = {
             prompt: input.prompt,
             image: baseImageData.buffer.toString('base64'),
+            width,
+            height,
             steps: 28,
             guidance: 3.5, // Kontext uses lower guidance
             safety_tolerance: 2,
@@ -200,6 +211,8 @@ export class BFLProvider extends ImageProvider {
           requestBody = {
             prompt: input.prompt,
             image: baseImageData.buffer.toString('base64'),
+            width,
+            height,
             steps: 28,
             guidance: 30, // Higher guidance for inpainting
             output_format: 'png'

--- a/src/providers/stability.ts
+++ b/src/providers/stability.ts
@@ -138,6 +138,15 @@ export class StabilityProvider extends ImageProvider {
       // Extract base64 data from data URL or file path
       const baseImageData = await this.getImageBuffer(input.baseImage);
 
+      // Detect dimensions if not provided
+      let width = input.width;
+      let height = input.height;
+      if (!width || !height) {
+        const dimensions = await this.detectImageDimensions(input.baseImage);
+        width = width || dimensions.width;
+        height = height || dimensions.height;
+      }
+
       // Create multipart form data
       const boundary = `----FormBoundary${Date.now()}`;
       const parts: Buffer[] = [];
@@ -170,6 +179,13 @@ export class StabilityProvider extends ImageProvider {
         `--${boundary}\r\n` +
         `Content-Disposition: form-data; name="output_format"\r\n\r\n` +
         `png\r\n`
+      ));
+
+      // Add aspect ratio based on detected/provided dimensions
+      parts.push(Buffer.from(
+        `--${boundary}\r\n` +
+        `Content-Disposition: form-data; name="aspect_ratio"\r\n\r\n` +
+        `${this.getAspectRatio(width, height)}\r\n`
       ));
 
       // Add strength (how much to change the image)

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,8 @@ export const EditInputSchema = z.object({
   provider: z.string().optional().describe('Provider name (OPENAI, STABILITY, REPLICATE, GEMINI, IDEOGRAM, BFL, LEONARDO, FAL, CLIPDROP, MOCK, or "auto" for intelligent selection)'),
   baseImage: z.string().describe('Image to edit - supports data URLs (data:image/png;base64,...), file paths (/path/to/image.png), or file URLs (file:///path/to/image.png)'),
   maskImage: z.string().optional().describe('Mask image (optional) - supports data URLs, file paths, or file URLs'),
+  width: z.number().int().min(64).max(4096).optional().describe('Output image width in pixels (defaults to input image dimensions)'),
+  height: z.number().int().min(64).max(4096).optional().describe('Output image height in pixels (defaults to input image dimensions)'),
   model: z.string().optional().describe('Model name for the provider')
 });
 


### PR DESCRIPTION
## Summary
Automatically preserves original image aspect ratios during img-to-img transformations instead of forcing 1024x1024 output.

## Changes
- Added `width` and `height` optional parameters to `EditInput` schema
- Implemented `detectImageDimensions()` helper using sharp in base provider
- Updated BFL provider to use detected dimensions in both Kontext and Fill modes
- Updated STABILITY provider to use detected dimensions via aspect_ratio parameter
- Updated CLAUDE.md with dimension detection documentation

## Benefits
- Input images maintain their original aspect ratio when transformed
- 16:9 landscape images stay 16:9 instead of becoming square
- Portrait images preserve their vertical orientation
- Users can still override dimensions manually if desired

## Technical Details
- Uses `sharp` library for accurate dimension detection from buffers, data URLs, and file paths
- Dimensions auto-detected if not explicitly provided
- Falls back to input image dimensions when width/height not specified
- BFL and STABILITY providers fully support custom dimensions
- GEMINI provider only supports 1:1 (documented limitation)

## Testing
- Type checking passes
- Build successful
- Manual testing recommended with various aspect ratios

## Breaking Changes
None - backward compatible with existing code